### PR TITLE
feat: add resource_class parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ project settings CircleCI. Then include the following in your `.circleci/config.
 version: 2.1
 setup: true
 orbs:
-  build: mojaloop/build@1.0.63
+  build: mojaloop/build@1.0.64
 workflows:
   setup:
     jobs:
@@ -25,8 +25,29 @@ workflows:
           filters:
             tags:
               only: /v\d+(\.\d+){2}(-[a-zA-Z-][0-9a-zA-Z-]*\.\d+)?/
-          # optionally supply the base image for the image scan
-          # base_image: org/image
+          # optionally supply the resource_class for the jobs
+          # pr_title_check_resource_class: medium
+          # setup_resource_class: medium
+          # test_dependencies_resource_class: medium
+          # test_deprecations_resource_class: medium
+          # test_lint_resource_class: medium
+          # test_unit_resource_class: medium
+          # test_coverage_resource_class: medium
+          # vulnerability_check_resource_class: medium
+          # license_audit_resource_class: medium
+          # build_local_resource_class: medium
+          # test_integration_resource_class: medium
+          # test_functional_resource_class: medium
+          # license_scan_resource_class: medium
+          # grype_image_scan_resource_class: medium
+          # release_resource_class: medium
+          # github_release_resource_class: medium
+          # publish_docker_resource_class: medium
+          # publish_npm_resource_class: medium
+          # publish_docker_snapshot_resource_class: medium
+          # publish_npm_snapshot_resource_class: medium
+          # publish_npm_prerelease_resource_class: medium
+          # publish_docker_prerelease_resource_class: medium
 ```
 
 ### Vulnerability Image Scan Configuration

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ project settings CircleCI. Then include the following in your `.circleci/config.
 version: 2.1
 setup: true
 orbs:
-  build: mojaloop/build@1.0.64
+  build: mojaloop/build@1.0.65
 workflows:
   setup:
     jobs:

--- a/src/examples/build_and_test.yml
+++ b/src/examples/build_and_test.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   setup: true
   orbs:
-    build: mojaloop/build@1.0.64
+    build: mojaloop/build@1.0.65
   workflows:
     setup:
       jobs:

--- a/src/examples/build_and_test.yml
+++ b/src/examples/build_and_test.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   setup: true
   orbs:
-    build: mojaloop/build@1.0.63
+    build: mojaloop/build@1.0.64
   workflows:
     setup:
       jobs:

--- a/src/executors/docker.yml
+++ b/src/executors/docker.yml
@@ -8,3 +8,10 @@ environment:
   NVM_ARCH_UNOFFICIAL_OVERRIDE: x64-musl ## Ref: https://github.com/nvm-sh/nvm/issues/1102#issuecomment-550572252
 docker:
   - image: node:22.15.0-alpine3.21 # Ref: https://hub.docker.com/_/node/tags?name=22.15.0-alpine3.21
+parameters:
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+    description: The resource class to use for the executor
+resource_class: << parameters.resource_class >>

--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -6,3 +6,10 @@ environment:
   BUILD_LIBRDKAFKA: 0
 machine:
   image: ubuntu-2404:2024.11.1 # Ref: https://circleci.com/developer/machine/image/ubuntu-2404
+parameters:
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+    description: The resource class to use for the executor
+resource_class: << parameters.resource_class >>

--- a/src/jobs/audit_licenses.yml
+++ b/src/jobs/audit_licenses.yml
@@ -1,12 +1,18 @@
 description: |
   This job runs the license-scanner to check the licenses of the dependencies.
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
   yarn_lock:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - license_scanner

--- a/src/jobs/build_local.yml
+++ b/src/jobs/build_local.yml
@@ -1,12 +1,18 @@
 description: |
   This job builds a local Docker image of the project.
-executor: machine
+executor:
+  name: machine
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
   yarn_lock:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - checkout
   - check_dockerfile

--- a/src/jobs/github_release.yml
+++ b/src/jobs/github_release.yml
@@ -1,6 +1,8 @@
 description: |
   This job creates a Github release for the project.
-executor: machine
+executor:
+  name: machine
+  resource_class: << parameters.resource_class >>
 shell: "/bin/bash -eo pipefail"
 environment:
   MAIN_BRANCH_NAME: main
@@ -8,6 +10,10 @@ parameters:
   slack:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - run:
       name: Install git

--- a/src/jobs/grype_image_scan.yml
+++ b/src/jobs/grype_image_scan.yml
@@ -1,11 +1,18 @@
 description: |
   This job scans the Docker image for vulnerabilities using Grype.
-executor: machine
+executor:
+  name: machine
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
   BASH_ENV: /etc/profile ## Ref: https://circleci.com/docs/env-vars/#alpine-linux
   ENV: ~/.profile
   NVM_ARCH_UNOFFICIAL_OVERRIDE: x64-musl ## Ref: https://github.com/nvm-sh/nvm/issues/1102#issuecomment-550572252
+parameters:
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - checkout
   - attach_workspace:

--- a/src/jobs/license_scan.yml
+++ b/src/jobs/license_scan.yml
@@ -1,7 +1,14 @@
 description: |
   This job is responsible for scanning the licenses of the docker image
   built in the previous job.
-executor: machine
+executor:
+  name: machine
+  resource_class: << parameters.resource_class >>
+parameters:
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 environment:
   MAIN_BRANCH_NAME: main
 steps:

--- a/src/jobs/pr_title_check.yaml
+++ b/src/jobs/pr_title_check.yaml
@@ -1,9 +1,15 @@
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 parameters:
   ci-config-branch:
     description: The branch of mojaloop/ci-config to bootstrap from
     default: master
     type: string
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - pr_title_check:
       ci-config-branch: << parameters.ci-config-branch >>

--- a/src/jobs/publish_docker.yml
+++ b/src/jobs/publish_docker.yml
@@ -1,6 +1,8 @@
 description: |
   This job publishes the Docker image built in the previous job to Docker Hub.
-executor: machine
+executor:
+  name: machine
+  resource_class: << parameters.resource_class >>
 shell: "/bin/bash -eo pipefail"
 environment:
   MAIN_BRANCH_NAME: main
@@ -8,6 +10,10 @@ parameters:
   slack:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - checkout
   - check_dockerfile

--- a/src/jobs/publish_docker_prerelease.yml
+++ b/src/jobs/publish_docker_prerelease.yml
@@ -1,6 +1,8 @@
 description: |
   This job is responsible for publishing the docker image pre-release to Docker Hub.
-executor: machine
+executor:
+  name: machine
+  resource_class: << parameters.resource_class >>
 shell: "/bin/bash -eo pipefail"
 environment:
   MAIN_BRANCH_NAME: main
@@ -8,6 +10,10 @@ parameters:
   slack:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - checkout
   - check_dockerfile

--- a/src/jobs/publish_docker_snapshot.yml
+++ b/src/jobs/publish_docker_snapshot.yml
@@ -1,6 +1,8 @@
 description: |
   This job is responsible for publishing the docker image snapshot to Docker Hub.
-executor: machine
+executor:
+  name: machine
+  resource_class: << parameters.resource_class >>
 shell: "/bin/bash -eo pipefail"
 environment:
   MAIN_BRANCH_NAME: main
@@ -8,6 +10,10 @@ parameters:
   slack:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - checkout
   - check_dockerfile

--- a/src/jobs/publish_npm.yml
+++ b/src/jobs/publish_npm.yml
@@ -1,6 +1,8 @@
 description: |
   This job publishes to npm.
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
@@ -10,6 +12,10 @@ parameters:
   slack:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - checkout

--- a/src/jobs/publish_npm_prerelease.yml
+++ b/src/jobs/publish_npm_prerelease.yml
@@ -1,6 +1,8 @@
 description: |
   This job publishes a pre-release to NPM.
-executor: machine
+executor:
+  name: machine
+  resource_class: << parameters.resource_class >>
 shell: /bin/bash -eo pipefail
 environment:
   MAIN_BRANCH_NAME: main
@@ -11,6 +13,10 @@ parameters:
   slack:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - run:
       name: Install git

--- a/src/jobs/publish_npm_snapshot.yml
+++ b/src/jobs/publish_npm_snapshot.yml
@@ -1,6 +1,8 @@
 description: |
   This job publishes a snapshot pre-release to NPM.
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
@@ -10,6 +12,10 @@ parameters:
   slack:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - checkout

--- a/src/jobs/release.yml
+++ b/src/jobs/release.yml
@@ -1,6 +1,8 @@
 description: >
   This job publishes a release to GitHub.
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
@@ -10,6 +12,10 @@ parameters:
   slack:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - checkout

--- a/src/jobs/setup.yml
+++ b/src/jobs/setup.yml
@@ -1,6 +1,8 @@
 description: >
   Setup node.js and install dependencies.
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
@@ -10,6 +12,10 @@ parameters:
   yarn_lock:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - when:

--- a/src/jobs/test_coverage.yml
+++ b/src/jobs/test_coverage.yml
@@ -1,5 +1,7 @@
 description: Run code coverage check
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
@@ -9,6 +11,10 @@ parameters:
   aws:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - when:

--- a/src/jobs/test_dependencies.yml
+++ b/src/jobs/test_dependencies.yml
@@ -1,12 +1,18 @@
 description: >
   This job tests the project's dependencies.
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
   yarn_lock:
     type: string
     default: ""
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - checkout

--- a/src/jobs/test_deprecations.yml
+++ b/src/jobs/test_deprecations.yml
@@ -1,12 +1,18 @@
 description: >
   This job tests for deprecated dependencies, at any level
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
   yarn_lock:
     type: string
     default: ""
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - checkout

--- a/src/jobs/test_functional.yml
+++ b/src/jobs/test_functional.yml
@@ -1,12 +1,18 @@
 description:
   This job executes the functional tests for the project.
-executor: machine
+executor:
+  name: machine
+  resource_class: << parameters.resource_class >>
 environment:
   ML_CORE_TEST_HARNESS_DIR: /tmp/ml-core-test-harness
 parameters:
   yarn_lock:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - checkout
   - attach_workspace:

--- a/src/jobs/test_integration.yml
+++ b/src/jobs/test_integration.yml
@@ -1,12 +1,18 @@
 description: >
   This job executes the integration tests for the project.
-executor: machine
+executor:
+  name: machine
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
   yarn_lock:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - machine_dependencies
   - checkout

--- a/src/jobs/test_lint.yml
+++ b/src/jobs/test_lint.yml
@@ -1,12 +1,18 @@
 description: |
   This job executes lint tests on the project.
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
   yarn_lock:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - checkout

--- a/src/jobs/test_unit.yml
+++ b/src/jobs/test_unit.yml
@@ -1,12 +1,18 @@
 description: |
   This job executes lint tests on the project.
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
   yarn_lock:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - checkout

--- a/src/jobs/vulnerability_check.yml
+++ b/src/jobs/vulnerability_check.yml
@@ -1,12 +1,18 @@
 description: |
   This job checks for vulnerabilities in the project.
-executor: docker
+executor:
+  name: docker
+  resource_class: << parameters.resource_class >>
 environment:
   MAIN_BRANCH_NAME: main
 parameters:
   yarn_lock:
     type: string
     default: ''
+  resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 steps:
   - docker_dependencies
   - checkout

--- a/src/jobs/workflow.yml
+++ b/src/jobs/workflow.yml
@@ -1,9 +1,94 @@
 description: >
   Runs build and test workflow
 parameters:
-  base_image:
-    type: string
-    default: ''
+  pr_title_check_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  setup_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_dependencies_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_deprecations_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_lint_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_unit_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_coverage_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  vulnerability_check_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  license_audit_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  build_local_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_integration_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_functional_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  license_scan_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  grype_image_scan_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  release_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  github_release_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_docker_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_npm_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_docker_snapshot_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_npm_snapshot_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_npm_prerelease_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_docker_prerelease_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 executor: continuation/default
 steps:
   - checkout
@@ -14,7 +99,28 @@ steps:
       command: |
         echo "$SCRIPT" > /tmp/build_and_test.yml
         echo '{
-          "base_image":"<< parameters.base_image >>",
+          "pr_title_check_resource_class":"<< parameters.pr_title_check_resource_class>>",
+          "setup_resource_class":"<< parameters.setup_resource_class>>",
+          "test_dependencies_resource_class":"<< parameters.test_dependencies_resource_class>>",
+          "test_deprecations_resource_class":"<< parameters.test_deprecations_resource_class>>",
+          "test_lint_resource_class":"<< parameters.test_lint_resource_class>>",
+          "test_unit_resource_class":"<< parameters.test_unit_resource_class>>",
+          "test_coverage_resource_class":"<< parameters.test_coverage_resource_class>>",
+          "vulnerability_check_resource_class":"<< parameters.vulnerability_check_resource_class>>",
+          "license_audit_resource_class":"<< parameters.license_audit_resource_class>>",
+          "build_local_resource_class":"<< parameters.build_local_resource_class>>",
+          "test_integration_resource_class":"<< parameters.test_integration_resource_class>>",
+          "test_functional_resource_class":"<< parameters.test_functional_resource_class>>",
+          "license_scan_resource_class":"<< parameters.license_scan_resource_class>>",
+          "grype_image_scan_resource_class":"<< parameters.grype_image_scan_resource_class>>",
+          "release_resource_class":"<< parameters.release_resource_class>>",
+          "github_release_resource_class":"<< parameters.github_release_resource_class>>",
+          "publish_docker_resource_class":"<< parameters.publish_docker_resource_class>>",
+          "publish_npm_resource_class":"<< parameters.publish_npm_resource_class>>",
+          "publish_docker_snapshot_resource_class":"<< parameters.publish_docker_snapshot_resource_class>>",
+          "publish_npm_snapshot_resource_class":"<< parameters.publish_npm_snapshot_resource_class>>",
+          "publish_npm_prerelease_resource_class":"<< parameters.publish_npm_prerelease_resource_class>>",
+          "publish_docker_prerelease_resource_class":"<< parameters.publish_docker_prerelease_resource_class>>",
           "git_tag":"'$CIRCLE_CI_TAG'",
           "pull_request":"'$CIRCLE_PULL_REQUEST'",
           "yarn_lock":"'$(test -f yarn.lock && echo "true" || echo "")'",

--- a/src/workflows/build_and_test.yml
+++ b/src/workflows/build_and_test.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  build: mojaloop/build@1.0.63
+  build: mojaloop/build@1.0.64
 parameters:
   git_tag:
     type: string
@@ -17,15 +17,101 @@ parameters:
   aws:
     type: string
     default: ""
-  base_image:
-    type: string
-    default: ""
+  pr_title_check_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  setup_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_dependencies_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_deprecations_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_lint_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_unit_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_coverage_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  vulnerability_check_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  license_audit_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  build_local_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_integration_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  test_functional_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  license_scan_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  grype_image_scan_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  release_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  github_release_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_docker_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_npm_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_docker_snapshot_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_npm_snapshot_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_npm_prerelease_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
+  publish_docker_prerelease_resource_class:
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: medium
 workflows:
   checks:
     when: << pipeline.parameters.pull_request >>
     jobs:
       - build/pr_title_check:
           name: PR title
+          resource_class: << pipeline.parameters.pr_title_check_resource_class >>
           filters:
             branches:
               ignore:
@@ -35,6 +121,7 @@ workflows:
     jobs:
       - build/setup:
           name: Setup
+          resource_class: << pipeline.parameters.setup_resource_class >>
           yarn_lock: << pipeline.parameters.yarn_lock >>
           filters: &setup-filter
             branches:
@@ -45,6 +132,7 @@ workflows:
               only: /v\d+(\.\d+){2}(-[a-zA-Z-][0-9a-zA-Z-]*\.\d+)?/
       - build/test_dependencies:
           name: Dependencies
+          resource_class: << pipeline.parameters.test_dependencies_resource_class >>
           yarn_lock: << pipeline.parameters.yarn_lock >>
           filters:
             branches:
@@ -55,12 +143,14 @@ workflows:
             - Setup
       - build/test_deprecations:
           name: Deprecations
+          resource_class: << pipeline.parameters.test_deprecations_resource_class >>
           yarn_lock: << pipeline.parameters.yarn_lock >>
           filters: *setup-filter
           requires:
             - Setup
       - build/test_lint: &test-condition
           name: Lint
+          resource_class: << pipeline.parameters.test_lint_resource_class >>
           yarn_lock: << pipeline.parameters.yarn_lock >>
           filters: *setup-filter
           requires:
@@ -68,31 +158,39 @@ workflows:
       - build/test_unit:
           <<: *test-condition
           name: Unit tests
+          resource_class: << pipeline.parameters.test_unit_resource_class >>
       - build/test_coverage:
           <<: *test-condition
           name: Coverage
           aws: << pipeline.parameters.aws >>
+          resource_class: << pipeline.parameters.test_coverage_resource_class >>
       - build/vulnerability_check:
           <<: *test-condition
           name: Vulnerability check
+          resource_class: << pipeline.parameters.vulnerability_check_resource_class >>
       - build/audit_licenses:
           <<: *test-condition
           name: License audit
+          resource_class: << pipeline.parameters.license_audit_resource_class >>
       - build/build_local:
           <<: *test-condition
           name: Build
+          resource_class: << pipeline.parameters.build_local_resource_class >>
           context: org-global
       - build/test_integration: &test-docker
           name: Integration tests
+          resource_class: << pipeline.parameters.test_integration_resource_class >>
           yarn_lock: << pipeline.parameters.yarn_lock >>
           filters: *setup-filter
           requires:
             - Build
       - build/test_functional:
-          name: Functional tests
           <<: *test-docker
+          name: Functional tests
+          resource_class: << pipeline.parameters.test_functional_resource_class >>
       - build/license_scan: &scan
           name: License scan
+          resource_class: << pipeline.parameters.license_scan_resource_class >>
           context: org-global
           filters:
             branches:
@@ -103,6 +201,7 @@ workflows:
             - Build
       - build/grype_image_scan: &grype_image_scan
           name: Grype image scan
+          resource_class: << pipeline.parameters.grype_image_scan_resource_class >>
           context: org-global
           filters:
             branches:
@@ -112,6 +211,7 @@ workflows:
             - Build
       - build/release:
           name: Release
+          resource_class: << pipeline.parameters.release_resource_class >>
           yarn_lock: << pipeline.parameters.yarn_lock >>
           slack: << pipeline.parameters.slack >>
           context: org-global
@@ -133,6 +233,7 @@ workflows:
             - Grype image scan
       - build/github_release:
           name: GitHub release
+          resource_class: << pipeline.parameters.github_release_resource_class >>
           slack: << pipeline.parameters.slack >>
           context: org-global
           filters: *release
@@ -140,6 +241,7 @@ workflows:
             - Release
       - build/publish_docker: &publish-job
           name: Docker release
+          resource_class: << pipeline.parameters.publish_docker_resource_class >>
           slack: << pipeline.parameters.slack >>
           context: org-global
           filters:
@@ -150,12 +252,14 @@ workflows:
               only: /v\d+(\.\d+){2}/
           requires: *tests
       - build/publish_npm:
+          <<: *publish-job
           name: NPM release
+          resource_class: << pipeline.parameters.publish_npm_resource_class >>
           yarn_lock: << pipeline.parameters.yarn_lock >>
           slack: << pipeline.parameters.slack >>
-          <<: *publish-job
       - build/publish_docker_snapshot: &publish-snapshot-job
           name: Docker snapshot
+          resource_class: << pipeline.parameters.publish_docker_snapshot_resource_class >>
           slack: << pipeline.parameters.slack >>
           context: org-global
           filters:
@@ -166,12 +270,14 @@ workflows:
               only: /v\d+(\.\d+){2}-(snapshot|hotfix|perf)\.\d+/
           requires: *tests
       - build/publish_npm_snapshot:
+          <<: *publish-snapshot-job
           name: NPM snapshot
+          resource_class: << pipeline.parameters.publish_npm_snapshot_resource_class >>
           yarn_lock: << pipeline.parameters.yarn_lock >>
           slack: << pipeline.parameters.slack >>
-          <<: *publish-snapshot-job
       - build/publish_npm_prerelease:
           name: NPM prerelease
+          resource_class: << pipeline.parameters.publish_npm_prerelease_resource_class >>
           yarn_lock: << pipeline.parameters.yarn_lock >>
           slack: << pipeline.parameters.slack >>
           context: org-global
@@ -189,6 +295,7 @@ workflows:
             - Grype image scan
       - build/publish_docker_prerelease:
           name: Docker prerelease
+          resource_class: << pipeline.parameters.publish_docker_prerelease_resource_class >>
           slack: << pipeline.parameters.slack >>
           context: org-global
           filters: *only-prerelease-branches

--- a/src/workflows/build_and_test.yml
+++ b/src/workflows/build_and_test.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  build: mojaloop/build@1.0.64
+  build: mojaloop/build@1.0.65
 parameters:
   git_tag:
     type: string


### PR DESCRIPTION
Add ability to control the resource class of the job docker and machine executors, with medium being the default so far. This seems to be needed for some UI tests that seem use too much RAM.
![image](https://github.com/user-attachments/assets/b2bc2582-86b0-4a16-a744-530b5df87d3d)
![image](https://github.com/user-attachments/assets/56350514-654b-407f-8efe-3ecda472c9b5)
