### PR TITLE
chore: bump orb version references to 1.1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ project settings CircleCI. Then include the following in your `.circleci/config.
 version: 2.1
 setup: true
 orbs:
-  build: mojaloop/build@1.1.17
+  build: mojaloop/build@1.1.20
 workflows:
   setup:
     jobs:

--- a/src/examples/build_and_test.yml
+++ b/src/examples/build_and_test.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   setup: true
   orbs:
-    build: mojaloop/build@1.1.17
+    build: mojaloop/build@1.1.20
   workflows:
     setup:
       jobs:

--- a/src/workflows/build_and_test.yml
+++ b/src/workflows/build_and_test.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  build: mojaloop/build@1.1.17
+  build: mojaloop/build@1.1.20
 parameters:
   git_tag:
     type: string


### PR DESCRIPTION
## Summary
- Update internal orb version references from 1.1.17 to 1.1.20 in README, workflow definition, and example

**Note:** The `context: org-global` fix for the PR title check rate limiting was already applied in PR #72 (v1.1.17) and is on `main`. This PR only bumps version references to match this release.

## Files changed
- `README.md` — usage example
- `src/workflows/build_and_test.yml` — internal workflow orb reference
- `src/examples/build_and_test.yml` — example configuration