### PR TITLE
feat: upgrade license scanner to provision for local exception list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ project settings CircleCI. Then include the following in your `.circleci/config.
 version: 2.1
 setup: true
 orbs:
-  build: mojaloop/build@2.0.0
+  build: mojaloop/build@2.1.0
 workflows:
   setup:
     jobs:

--- a/src/commands/license_gate.yml
+++ b/src/commands/license_gate.yml
@@ -11,7 +11,7 @@ parameters:
     description: Path to the CycloneDX SBOM to gate (produced by generate_sbom).
   version:
     type: string
-    default: "1.0.0"
+    default: "1.1.0"
     description: >
       Exact published @mojaloop/license-scanner-tool version to run. Pin exactly
       (not a range) for supply-chain safety; bump deliberately per orb release to

--- a/src/examples/build_and_test.yml
+++ b/src/examples/build_and_test.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   setup: true
   orbs:
-    build: mojaloop/build@2.0.0
+    build: mojaloop/build@2.1.0
   workflows:
     setup:
       jobs:

--- a/src/workflows/build_and_test.yml
+++ b/src/workflows/build_and_test.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  build: mojaloop/build@2.0.0
+  build: mojaloop/build@2.1.0
 parameters:
   git_tag:
     type: string


### PR DESCRIPTION
Now the repos can add a local `.license-scanner.json` file to add an exception for valid license during license scan