### PR TITLE
fix: bump license-scanner-tool to 1.1.1, orb refs to 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ project settings CircleCI. Then include the following in your `.circleci/config.
 version: 2.1
 setup: true
 orbs:
-  build: mojaloop/build@2.1.0
+  build: mojaloop/build@2.1.1
 workflows:
   setup:
     jobs:

--- a/src/commands/license_gate.yml
+++ b/src/commands/license_gate.yml
@@ -11,7 +11,7 @@ parameters:
     description: Path to the CycloneDX SBOM to gate (produced by generate_sbom).
   version:
     type: string
-    default: "1.1.0"
+    default: "1.1.1"
     description: >
       Exact published @mojaloop/license-scanner-tool version to run. Pin exactly
       (not a range) for supply-chain safety; bump deliberately per orb release to

--- a/src/examples/build_and_test.yml
+++ b/src/examples/build_and_test.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   setup: true
   orbs:
-    build: mojaloop/build@2.1.0
+    build: mojaloop/build@2.1.1
   workflows:
     setup:
       jobs:

--- a/src/workflows/build_and_test.yml
+++ b/src/workflows/build_and_test.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  build: mojaloop/build@2.1.0
+  build: mojaloop/build@2.1.1
 parameters:
   git_tag:
     type: string


### PR DESCRIPTION
Pins license-scanner-tool 1.1.1 (the SPDX OR/AND gate fix) so dual-licensed deps like node-forge pass, and bumps the orb version refs to 2.1.1.