### PR TITLE
fix: set node from .nvmrc in test_functional

### DIFF
--- a/src/examples/build_and_test.yml
+++ b/src/examples/build_and_test.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   setup: true
   orbs:
-    build: mojaloop/build@2.1.3
+    build: mojaloop/build@2.1.4
   workflows:
     setup:
       jobs:

--- a/src/jobs/test_functional.yml
+++ b/src/jobs/test_functional.yml
@@ -15,6 +15,7 @@ parameters:
     default: medium
 steps:
   - checkout
+  - configure_nvm
   - attach_workspace:
       at: /tmp
   - run:
@@ -25,7 +26,9 @@ steps:
         fi
   - run:
       name: Execute TTK functional tests
-      command: npm run test:functional
+      command: |
+        nvm use default
+        npm run test:functional
   - store_artifacts:
       path: /tmp/ml-core-test-harness/reports
       destination: test

--- a/src/workflows/build_and_test.yml
+++ b/src/workflows/build_and_test.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  build: mojaloop/build@2.1.3
+  build: mojaloop/build@2.1.4
 parameters:
   git_tag:
     type: string


### PR DESCRIPTION
test_functional ran on the machine executor's default Node, failing newer deps' engines check and desyncing `npm ci`. Add `configure_nvm` + `nvm use default`, matching every other test job.