### PR TITLE
feat: sign published Docker images with Cosign

### DIFF
--- a/src/commands/sign_docker_image.yml
+++ b/src/commands/sign_docker_image.yml
@@ -1,0 +1,59 @@
+description: >
+  Sign a published Docker image using Cosign and the image's immutable digest.
+
+parameters:
+  cosign_version:
+    type: string
+    default: "v3.1.3"
+    description: Pinned Cosign release installed when Cosign is not already present.
+
+steps:
+  - run:
+      name: Install Cosign (pinned) if missing
+      command: |
+        set -e
+
+        if command -v cosign >/dev/null 2>&1; then
+          cosign version
+          exit 0
+        fi
+
+        BINDIR=/usr/local/bin
+
+        if [ -w "$BINDIR" ]; then
+          SUDO=
+        else
+          SUDO=sudo
+        fi
+
+        curl -sSfL \
+          "https://github.com/sigstore/cosign/releases/download/<< parameters.cosign_version >>/cosign-linux-amd64" \
+          -o /tmp/cosign
+
+        $SUDO install /tmp/cosign "$BINDIR/cosign"
+
+        cosign version
+
+  - run:
+      name: Sign Docker image
+      command: |
+        set -e
+
+        KEY_FILE=/tmp/cosign.key
+
+        cleanup() {
+          rm -f "$KEY_FILE"
+        }
+
+        trap cleanup EXIT
+
+        echo "$COSIGN_PRIVATE_KEY_BASE64" \
+          | base64 --decode \
+          > "$KEY_FILE"
+
+        chmod 600 "$KEY_FILE"
+
+        cosign sign \
+          --yes \
+          --key "$KEY_FILE" \
+          "$IMAGE_DIGEST"

--- a/src/jobs/publish_docker.yml
+++ b/src/jobs/publish_docker.yml
@@ -58,9 +58,12 @@ steps:
   - run:
       name: Set Image Digest
       command: |
-        IMAGE_DIGEST=$(docker inspect ${DOCKER_ORG:-mojaloop}/$CIRCLE_PROJECT_REPONAME:v${CIRCLE_TAG:1} | jq '.[0].RepoDigests | .[]')
+        IMAGE_DIGEST=$(docker inspect ${DOCKER_ORG:-mojaloop}/$CIRCLE_PROJECT_REPONAME:v${CIRCLE_TAG:1} | jq -r '.[0].RepoDigests | .[]')
         echo "IMAGE_DIGEST=${IMAGE_DIGEST}"
         echo "export IMAGE_DIGEST=${IMAGE_DIGEST}" >> $BASH_ENV
+
+  - sign_docker_image
+
   - trigger_downstream
   - run:
       name: Update Slack config

--- a/src/jobs/publish_docker_prerelease.yml
+++ b/src/jobs/publish_docker_prerelease.yml
@@ -53,9 +53,12 @@ steps:
   - run:
       name: Set Image Digest
       command: |
-        IMAGE_DIGEST=$(docker inspect ${DOCKER_ORG:-mojaloop}/$CIRCLE_PROJECT_REPONAME:v${PACKAGE_VERSION} | jq '.[0].RepoDigests | .[]')
+        IMAGE_DIGEST=$(docker inspect ${DOCKER_ORG:-mojaloop}/$CIRCLE_PROJECT_REPONAME:v${PACKAGE_VERSION} | jq -r '.[0].RepoDigests | .[]')
         echo "IMAGE_DIGEST=${IMAGE_DIGEST}"
         echo "export IMAGE_DIGEST=${IMAGE_DIGEST}" >> $BASH_ENV
+
+  - sign_docker_image
+
   - trigger_downstream
   - run:
       name: Update Slack config

--- a/src/jobs/publish_docker_snapshot.yml
+++ b/src/jobs/publish_docker_snapshot.yml
@@ -58,9 +58,11 @@ steps:
   - run:
       name: Set Image Digest
       command: |
-        IMAGE_DIGEST=$(docker inspect ${DOCKER_ORG:-mojaloop}/$CIRCLE_PROJECT_REPONAME:v${CIRCLE_TAG:1} | jq '.[0].RepoDigests | .[]')
+        IMAGE_DIGEST=$(docker inspect ${DOCKER_ORG:-mojaloop}/$CIRCLE_PROJECT_REPONAME:v${CIRCLE_TAG:1} | jq -r '.[0].RepoDigests | .[]')
         echo "IMAGE_DIGEST=${IMAGE_DIGEST}"
         echo "export IMAGE_DIGEST=${IMAGE_DIGEST}" >> $BASH_ENV
+
+  - sign_docker_image
   - run:
       name: Update Slack config
       command: |


### PR DESCRIPTION
# Summary

Initial implementation for Docker image signing with Cosign as part of [mojaloop/project#4527](https://github.com/mojaloop/project/issues/4527).

This adds a reusable `sign_docker_image` command and integrates it into the Docker release, snapshot, and prerelease publish jobs. Images are signed using their immutable digest after being pushed to the registry.

## Status

**Work in progress.** This PR is currently being used to validate the CircleCI orb integration. Public key publication/distribution is still to be implemented.